### PR TITLE
Migrate to new version of coverage

### DIFF
--- a/bin/test_coverage.dart
+++ b/bin/test_coverage.dart
@@ -12,7 +12,7 @@ import 'package:test_coverage/test_coverage.dart';
 Future main(List<String> arguments) async {
   final packageRoot = Directory.current;
 
-  final parser = new ArgParser();
+  final parser = ArgParser();
   parser.addFlag('help', abbr: 'h', help: 'Show usage', negatable: false);
   parser.addOption(
     'exclude',
@@ -38,7 +38,7 @@ Future main(List<String> arguments) async {
 
   Glob excludeGlob;
   if (options['exclude'] is String) {
-    excludeGlob = new Glob(options['exclude']);
+    excludeGlob = Glob(options['exclude']);
   }
 
   String port = options['port'];

--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -104,7 +104,7 @@ Future<void> runTestsAndCollect(String packageRoot, String port) async {
   });
 
   if (serviceUri == null) {
-    throw new StateError("Could not run tests with Observatory enabled. "
+    throw StateError("Could not run tests with Observatory enabled. "
         "Try setting a different port with --port option.");
   }
 

--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -110,7 +110,7 @@ Future<void> runTestsAndCollect(String packageRoot, String port) async {
 
   Map<String, Map<int, int>> hitmap;
   try {
-    final data = await coverage.collect(serviceUri, true, true);
+    final data = await coverage.collect(serviceUri, true, true, false, {});
     hitmap = coverage.createHitmap(data['coverage']);
   } finally {
     await process.stderr.drain<List<int>>();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ executables:
   test_coverage:
 
 dependencies:
-  coverage: ^0.12.1
+  coverage: ^0.13.0
   path: ^1.6.1
   lcov: ^5.3.0
   glob: ^1.1.7


### PR DESCRIPTION
@pulyaevskiy With the addition of coverage as a dependency for the test package, I noticed this package bars my app from using the latest test related packages.

I bumped the version for the coverage package and adapted the use of coverage's collect function to pass 5 parameters instead of 3.

Note to Reviewer: My tests ran for about 24 seconds before this change and now it processes the tests in about 7 seconds. I don't know if the parameter values I'm passing impact this. Likely, passing a `false` for the dart parameter drops checking coverage of the `dart:` packages.