### PR TITLE
Drop use of new keyword after migration to Dart 2.0

### DIFF
--- a/bin/test_coverage.dart
+++ b/bin/test_coverage.dart
@@ -12,7 +12,7 @@ import 'package:test_coverage/test_coverage.dart';
 Future main(List<String> arguments) async {
   final packageRoot = Directory.current;
 
-  final parser = new ArgParser();
+  final parser = ArgParser();
   parser.addFlag('help', abbr: 'h', help: 'Show usage', negatable: false);
   parser.addOption(
     'exclude',
@@ -38,7 +38,7 @@ Future main(List<String> arguments) async {
 
   Glob excludeGlob;
   if (options['exclude'] is String) {
-    excludeGlob = new Glob(options['exclude']);
+    excludeGlob = Glob(options['exclude']);
   }
 
   String port = options['port'];

--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -104,7 +104,7 @@ Future<void> runTestsAndCollect(String packageRoot, String port) async {
   });
 
   if (serviceUri == null) {
-    throw new StateError("Could not run tests with Observatory enabled. "
+    throw StateError("Could not run tests with Observatory enabled. "
         "Try setting a different port with --port option.");
   }
 


### PR DESCRIPTION
Since the package depends on Dart 2.0 now and has analysis lints warning of the use of `new` keyword, I went ahead and dropped the use of `new` keyword.