### PR TITLE
Fix test generator for windows platforms

### DIFF
--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -44,7 +44,7 @@ class TestFileInfo {
     }
     relative = relative.reversed.toList();
     final alias = relative.join('_').replaceFirst('.dart', '');
-    final importPath = relative.join(_sep);
+    final importPath = relative.join('/');
     final import = "import '$importPath' as $alias;";
     return TestFileInfo._(testFile, alias, import);
   }


### PR DESCRIPTION
Dart expects `import` statments to use `/` regardless of the platform its running on