### PR TITLE
add pretty print output file

### DIFF
--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -136,6 +136,12 @@ Future<void> runTestsAndCollect(String packageRoot, String port,
     coverageDir.createSync();
   }
   File(path.join(coveragePath, 'lcov.info')).writeAsStringSync(coverageData);
+
+  final prettyFormatter = coverage.PrettyPrintFormatter(
+      resolver, coverage.Loader(),
+      reportOn: ['lib${path.separator}']);
+  final jsonData = await prettyFormatter.format(hitmap);
+  File(path.join(coveragePath, 'coverage.txt')).writeAsStringSync(jsonData);
 }
 
 // copied from `coverage` package

--- a/test/test_coverage_test.dart
+++ b/test/test_coverage_test.dart
@@ -24,6 +24,7 @@ void main() {
     final savedCurrent = Directory.current;
     final testFile = File(path.join(stubPath, 'test', '.test_coverage.dart'));
     final lcovFile = File(path.join(coverageDir.path, 'lcov.info'));
+    final prettyFile = File(path.join(coverageDir.path, 'coverage.txt'));
     final badgeFile = File(path.join(stubPath, 'coverage_badge.svg'));
 
     setUp(() {
@@ -55,6 +56,7 @@ void main() {
       await runTestsAndCollect(stubPath, '8585');
 
       expect(lcovFile.existsSync(), isTrue);
+      expect(prettyFile.existsSync(), isTrue);
 
       final coverageValue = calculateLineCoverage(lcovFile);
       expect(coverageValue, 1.0);


### PR DESCRIPTION
I'm working on windows which doesn't really have lcov support.
So to still be able to view code coverage I added the "pretty printing" result to an output file called "coverage.txt"