### PR TITLE
Update dependencies for NNBD

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,11 +11,9 @@ executables:
   test_coverage:
 
 dependencies:
-  coverage: ^0.14.1
-  path: ^1.6.1
+  coverage: ^0.15.2
   lcov: ^5.3.0
-  glob: ^1.1.7
-  args: ^1.5.1
+  glob: '>=1.1.7 <3.0.0'
 
 dev_dependencies:
   test: ^1.0.0


### PR DESCRIPTION
This loosens dependency constraints and makes test_coverage use args and path transitively.
These changes allow consuming this package from a NNBD project that otherwise might run into dependency conflicts.

Specifically, I ran into conflicts when fixing dependencies for https://github.com/corsac-dart/jwt/pull/21.

I opted not to migrate this library to NNBD just yet because `lcov` and `coverage` have not yet migrated.

Related issue: #33.