### PR TITLE
Null safety migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.0
+
+- Migrated code to null safety (#33)
+- Removed discontinued lcov dependency (#38)
+
 ## 0.5.0
 
 - Updated dependency on coverage package to ^0.14.1 (#24)

--- a/bin/test_coverage.dart
+++ b/bin/test_coverage.dart
@@ -45,12 +45,12 @@ Future main(List<String> arguments) async {
     return;
   }
 
-  Glob excludeGlob;
+  Glob? excludeGlob;
   if (options['exclude'] is String) {
     excludeGlob = Glob(options['exclude']);
   }
 
-  String port = options['port'];
+  String? port = options['port'];
 
   final testFiles = findTestFiles(packageRoot, excludeGlob: excludeGlob);
   print('Found ${testFiles.length} test files.');

--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -7,7 +7,6 @@ import 'dart:io';
 
 import 'package:coverage/coverage.dart' as coverage;
 import 'package:glob/glob.dart';
-import 'package:lcov/lcov.dart';
 import 'package:path/path.dart' as path;
 
 final _sep = path.separator;
@@ -153,13 +152,16 @@ Uri _extractObservatoryUri(String str) {
 }
 
 double calculateLineCoverage(File lcovReport) {
-  final report = Report.fromCoverage(lcovReport.readAsStringSync());
+  final lflhRegex = RegExp(r'(LF|LH):\d*$');
+  final reportFileContent = lcovReport.readAsLinesSync();
+  reportFileContent.retainWhere((l) => lflhRegex.hasMatch(l));
   var totalLines = 0;
   var hitLines = 0;
-  for (final rec in report.records) {
-    for (final line in rec.lines.data) {
+  for (final line in reportFileContent) {
+    if (line.startsWith('LF')) {
       totalLines++;
-      hitLines += (line.executionCount > 0) ? 1 : 0;
+    } else {
+      hitLines++;
     }
   }
   return hitLines / totalLines;

--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -11,7 +11,7 @@ import 'package:path/path.dart' as path;
 
 final _sep = path.separator;
 
-List<File> findTestFiles(Directory packageRoot, {Glob excludeGlob}) {
+List<File> findTestFiles(Directory packageRoot, {Glob? excludeGlob}) {
   final testsPath = path.join(packageRoot.absolute.path, 'test');
   final testsRoot = Directory(testsPath);
   final contents = testsRoot.listSync(recursive: true);
@@ -74,7 +74,7 @@ void generateMainScript(Directory packageRoot, List<File> testFiles) {
   ).writeAsStringSync(buffer.toString());
 }
 
-Future<void> runTestsAndCollect(String packageRoot, String port,
+Future<void> runTestsAndCollect(String packageRoot, String? port,
     {bool printOutput = false}) async {
   final script = path.join(packageRoot, 'test', '.test_coverage.dart');
   final dartArgs = [
@@ -85,7 +85,7 @@ Future<void> runTestsAndCollect(String packageRoot, String port,
   ];
   final process =
       await Process.start('dart', dartArgs, workingDirectory: packageRoot);
-  final serviceUriCompleter = Completer<Uri>();
+  final serviceUriCompleter = Completer<Uri?>();
   process.stdout
       .transform(utf8.decoder)
       .transform(const LineSplitter())
@@ -114,7 +114,7 @@ Future<void> runTestsAndCollect(String packageRoot, String port,
     final data = await coverage.collect(serviceUri, true, true, false, {});
     hitmap = await coverage.createHitmap(data['coverage']);
   } finally {
-    await process.stderr.drain<List<int>>();
+    await process.stderr.drain<List<int>?>();
   }
   final exitStatus = await process.exitCode;
   if (exitStatus != 0) {
@@ -138,7 +138,7 @@ Future<void> runTestsAndCollect(String packageRoot, String port,
 }
 
 // copied from `coverage` package
-Uri _extractObservatoryUri(String str) {
+Uri? _extractObservatoryUri(String str) {
   const kObservatoryListening = 'Observatory listening on ';
   final msgPos = str.indexOf(kObservatoryListening);
   if (msgPos == -1) return null;
@@ -189,7 +189,11 @@ class _BadgeMetrics {
   final int rightX;
   final int rightLength;
 
-  _BadgeMetrics({this.width, this.rightX, this.rightLength});
+  _BadgeMetrics({
+    required this.width,
+    required this.rightX,
+    required this.rightLength,
+  });
 
   factory _BadgeMetrics.forPercentage(double value) {
     final pct = (value * 100).floor();
@@ -223,8 +227,8 @@ String _color(double percentage) {
     0.9: _Color(0x97, 0xCA, 0x00),
     1.0: _Color(0x44, 0xCC, 0x11),
   };
-  double lower;
-  double upper;
+  late double lower;
+  double? upper;
   for (final key in map.keys) {
     if (percentage < key) {
       upper = key;
@@ -233,8 +237,8 @@ String _color(double percentage) {
     if (key < 1.0) lower = key;
   }
   upper ??= 1.0;
-  final lowerColor = map[lower];
-  final upperColor = map[upper];
+  final lowerColor = map[lower]!;
+  final upperColor = map[upper]!;
   final range = upper - lower;
   final rangePct = (percentage - lower) / range;
   final pctLower = 1 - rangePct;

--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -152,18 +152,21 @@ Uri? _extractObservatoryUri(String str) {
 }
 
 double calculateLineCoverage(File lcovReport) {
-  final lflhRegex = RegExp(r'(LF|LH):\d*$');
+  final lflhRegex = RegExp(r'^L[FH]:(\d*)$');
   final reportFileContent = lcovReport.readAsLinesSync();
   reportFileContent.retainWhere((l) => lflhRegex.hasMatch(l));
   var totalLines = 0;
   var hitLines = 0;
   for (final line in reportFileContent) {
+    var valueString = lflhRegex.matchAsPrefix(line)?.group(1) ?? '0';
+    var value = int.tryParse(valueString) ?? 0;
     if (line.startsWith('LF')) {
-      totalLines++;
+      totalLines += value;
     } else {
-      hitLines++;
+      hitLines += value;
     }
   }
+  if (totalLines == 0) return 1;
   return hitLines / totalLines;
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,17 +5,17 @@ homepage: https://github.com/pulyaevskiy/test-coverage
 author: Anatoly Pulyaevskiy <anatoly.pulyaevskiy@gmail.com>
 
 environment:
-  sdk: '>=2.3.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 executables:
   test_coverage:
 
 dependencies:
-  coverage: ^0.14.1
-  path: ^1.6.1
-  glob: ^1.1.7
-  args: ^1.5.1
+  coverage: ^1.0.1
+  path: ^1.8.0
+  glob: ^2.0.0
+  args: ^2.0.0
 
 dev_dependencies:
-  test: ^1.0.0
-  pedantic: ^1.7.0
+  test: ^1.16.7
+  pedantic: ^1.11.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: test_coverage
 description: Command line utility to run tests in Dart VM and collect coverage data.
-version: 0.5.0
+version: 0.6.0
 homepage: https://github.com/pulyaevskiy/test-coverage
 author: Anatoly Pulyaevskiy <anatoly.pulyaevskiy@gmail.com>
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,6 @@ executables:
 dependencies:
   coverage: ^0.14.1
   path: ^1.6.1
-  lcov: ^5.3.0
   glob: ^1.1.7
   args: ^1.5.1
 


### PR DESCRIPTION
This pull request removes discontinued [lcov](https://pub.dev/packages/lcov) dependency and migrates the package to null safety.

Following Flutter [guidelines](https://dart.dev/null-safety/migration-guide#package-version), package version gets updated from `0.5.0` to `0.6.0`

Closes #38 , #37, #33 